### PR TITLE
Need severity  and type information when list all rules.

### DIFF
--- a/src/main/java/org/sonarsource/sonarlint/ls/Rule.java
+++ b/src/main/java/org/sonarsource/sonarlint/ls/Rule.java
@@ -37,6 +37,14 @@ public class Rule {
   @Expose
   private boolean activeByDefault;
 
+  @SerializedName("severity")
+  @Expose
+  private String severity;
+
+  @SerializedName("type")
+  @Expose
+  private  String type;
+
   public String getKey() {
     return key;
   }
@@ -49,13 +57,19 @@ public class Rule {
     return activeByDefault;
   }
 
-  public Rule(String key, String name, boolean activeByDefault) {
+  public String getSeverity() {
+    return severity;
+  }
+
+  public Rule(String key, String name, boolean activeByDefault,String severity,String type) {
     this.key = key;
     this.name = name;
     this.activeByDefault = activeByDefault;
+    this.severity = severity;
+    this.type = type;
   }
 
   public static Rule of(StandaloneRuleDetails d) {
-    return new Rule(d.getKey(), d.getName(), d.isActiveByDefault());
+    return new Rule(d.getKey(), d.getName(), d.isActiveByDefault(),d.getSeverity(),d.getType());
   }
 }


### PR DESCRIPTION
In VSCODE, there is no icon for rule view.
But in JetBrains plugin there are icon.
I think we should add  severity filed  and type field to the class Rule. 
So we can using it to show the fit icon of Rule.